### PR TITLE
New interface for Catalog

### DIFF
--- a/lenscat/__init__.py
+++ b/lenscat/__init__.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
 from astropy.table import Table
-from .catalog import Catalog
+from .catalog import Catalog, CrossmatchResult
 
 # The relative path to the actual catalog in csv format
 _catalog_path = "data/catalog.csv"

--- a/lenscat/catalog.py
+++ b/lenscat/catalog.py
@@ -6,6 +6,7 @@ from astropy.table import Table
 from astropy.coordinates import SkyCoord
 from ligo.skymap.postprocess import crossmatch as ligoskymap_crossmatch
 from .utils import convert_to_astropy_unit, parse_skymap
+from .utils import plot_catalog, plot_crossmatch
 
 class Catalog(Table):
     _allowed_type = ["galaxy", "cluster"]
@@ -82,6 +83,9 @@ class Catalog(Table):
             filtered_catalog = filtered_catalog.filter_by_zlens(*zlens_range)
 
         return filtered_catalog
+
+    def plot(self, **kwargs):
+        return plot_catalog(self, **kwargs)
 
     def crossmatch(self, skymap):
         _skymap = parse_skymap(skymap, moc=True)

--- a/lenscat/catalog.py
+++ b/lenscat/catalog.py
@@ -19,16 +19,16 @@ class Catalog(Table):
     def hide_ref(self):
         try:
             self.pprint_exclude_names.add("ref")
-            return self
         except:
             pass # Fail silently
+        return self
 
     def show_ref(self):
         try:
             self.pprint_exclude_names.remove("ref")
-            return self
         except:
             pass # Fail silently
+        return self
 
     def filter_by_RA(self, RA_min=0.0, RA_max=360.0):
         assert RA_min < RA_max, "RA_max must be greater than RA_min"

--- a/lenscat/catalog.py
+++ b/lenscat/catalog.py
@@ -105,19 +105,20 @@ class Catalog(_Catalog):
     
         coordinates = SkyCoord(self["RA"], self["DEC"])
         result = ligoskymap_crossmatch(_skymap, coordinates)
-        table_with_result = CrossmatchResult(self.columns[:], skymap=skymap)
-        table_with_result.add_column(
+        crossmatch_result = CrossmatchResult(self.columns[:], skymap=skymap)
+        crossmatch_result.add_column(
             result.searched_prob,
             name="searched probability"
         )
-        table_with_result.add_column(
+    
+        crossmatch_result.add_column(
             result.searched_area,
             name="searched area"
         )
         # Searched areas are in sqdeg
-        table_with_result["searched area"].unit = u.deg**2
+        crossmatch_result["searched area"].unit = u.deg**2
 
         # Sort by searched prob, then by seared area
-        table_with_result.sort(["searched probability", "searched area"])
+        crossmatch_result.sort(["searched probability", "searched area"])
 
-        return table_with_result
+        return crossmatch_result

--- a/lenscat/catalog.py
+++ b/lenscat/catalog.py
@@ -110,7 +110,6 @@ class Catalog(_Catalog):
             result.searched_prob,
             name="searched probability"
         )
-    
         crossmatch_result.add_column(
             result.searched_area,
             name="searched area"
@@ -120,5 +119,10 @@ class Catalog(_Catalog):
 
         # Sort by searched prob, then by seared area
         crossmatch_result.sort(["searched probability", "searched area"])
+
+        # Regularize searched probability
+        for idx in range(len(crossmatch_result)):
+            if crossmatch_result[idx]["searched probability"] > 1.0:
+                crossmatch_result[idx]["searched probability"] = 1.0
 
         return crossmatch_result


### PR DESCRIPTION
This pull request implements a new interface for the `Catalog` class that allows for a more straightforward plotting.

Previously, in order to visualize the catalog (or a down-selected of), one needs to
```python
from lenscat.utils import plot_catalog

plot_catalog(lenscat.catalog)
```
And now, it is also simply as
```python
lenscat.catalog.plot()
```

Similarly to visualize a crossmatching result, one can do
```python
res = lenscat.catalog.crossmatch("PATH_TO_FITS_FILE"); res.plot()
```