### PR TITLE
Add numpy, pandas as dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setuptools.setup(
     install_requires=[
         "astropy >= 6.0.0",
         "ligo.skymap",
+        "numpy",
+        "pandas",
     ],
     classifiers=[
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR fixes #30 breaking the github automation, by explicitly adding `numpy` and `pandas` as dependencies